### PR TITLE
Update PHP version condition for Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
     "minimum-stability": "stable",
     "require": {
         "ext-curl": "*",
-        "php": "^7.0|^8.0"
+        "php": "^7.0 || ^8.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -14,7 +14,7 @@
     "prefer-lowest": false,
     "platform": {
         "ext-curl": "*",
-        "php": "^7.0|^8.0"
+        "php": "^7.0 || ^8.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.2.0"


### PR DESCRIPTION
According to the [Version Range](https://getcomposer.org/doc/articles/versions.md#version-range) docs, it is better to use the `||` operator for logical OR:

> Note: In older versions of Composer the single pipe (|) was the recommended alternative to the logical OR. Thus for backwards compatibility the single pipe (|) will still be treated as a logical OR.

